### PR TITLE
get fleet movements / get planet list and select one

### DIFF
--- a/src/Api/game/GameApi.ts
+++ b/src/Api/game/GameApi.ts
@@ -1,199 +1,240 @@
 import Axios, { AxiosInstance } from 'axios';
-import { Account } from '../lobby/types';
 import * as puppeteer from 'puppeteer';
-import {
-    ResourceList, ResourceFactoryList, Upgrade, ResourceType,
-    FacilitiesList, ResearchList, ShipList, Ship, DefenseList, Defense, Building, BuildingLight, BuildingList,
-} from './types';
-import { loadMinesAndStorage, loadResources } from './parsing/resources';
-import { loadFacilities } from './parsing/facilities';
-import { loadResearch } from './parsing/research';
-import { loadShips, createShipFromPannel } from './parsing/ship';
-import { createDefenseFromPannel, loadDefenses } from './parsing/defenses';
+import { Account } from '../lobby/types';
 import { Navigation } from './navigation';
+import { createDefenseFromPannel, loadDefenses } from './parsing/defenses';
+import { loadFacilities } from './parsing/facilities';
+import { loadFleetMovements } from './parsing/fleetMovements';
+import { loadPlanets } from './parsing/planets';
+import { loadResearch } from './parsing/research';
+import { loadMinesAndStorage, loadResources } from './parsing/resources';
+import { createShipFromPannel, loadShips } from './parsing/ship';
+import {
+  BuildingLight,
+  Defense,
+  DefenseList,
+  FacilitiesList,
+  FleetMovement,
+  Planet,
+  ResearchList,
+  ResourceFactoryList,
+  ResourceList,
+  ResourceType,
+  Ship,
+  ShipList,
+  Upgrade
+} from './types';
 
 /**
  * The GameApi is used to interact with the game itself, create and list ressources/ship/research...
  * You should use LobbyApi to load it, don't create it yourself
  */
 export class GameApi {
-    private account: Account;
-    private axios: AxiosInstance;
-    private browser: puppeteer.Browser;
-    private page: puppeteer.Page;
-    private cookie: string;
-    private loginUrl: string;
-    private navigation: Navigation;
+  private account: Account;
+  private axios: AxiosInstance;
+  private browser: puppeteer.Browser;
+  private page: puppeteer.Page;
+  private cookie: string;
+  private loginUrl: string;
+  private navigation: Navigation;
 
-    /**
-     * @hidden
-     */
-    constructor(cookie: string, account: Account, loginUrl: string) {
-        this.cookie = cookie;
-        this.loginUrl = loginUrl;
-        this.account = account;
-        this.axios = Axios.create({
-          withCredentials: true,
-          baseURL: this.__getServerUrl(),
-        });
-        this.axios.interceptors.request.use(config => {
-            if (!config.headers.cookie) {
-                config.headers.cookie = '';
-            }
-            config.headers.cookie += cookie;
-            return config;
-        });
-        this.navigation = new Navigation(this.__getServerUrl());
-    }
+  /**
+   * @hidden
+   */
+  constructor(cookie: string, account: Account, loginUrl: string) {
+    this.cookie = cookie;
+    this.loginUrl = loginUrl;
+    this.account = account;
+    this.axios = Axios.create({
+      withCredentials: true,
+      baseURL: this.__getServerUrl()
+    });
+    this.axios.interceptors.request.use(config => {
+      if (!config.headers.cookie) {
+        config.headers.cookie = '';
+      }
+      config.headers.cookie += cookie;
+      return config;
+    });
+    this.navigation = new Navigation(this.__getServerUrl());
+  }
 
-    /**
-     * Start the game api
-     */
-    async start(): Promise<void> {
-        this.browser = await puppeteer.launch();
-        this.page = await this.browser.newPage();
-        const [name, other] = this.cookie.split('=');
-        const [value] = other.split(';');
-        await this.page.setCookie({
-            name,
-            value,
-            url: this.__getServerUrl(),
-        });
-        await this.page.setViewport({
-            width: 1280,
-            height: 960,
-        });
-        await this.page.goto(this.loginUrl);
-    }
+  /**
+   * Start the game api
+   */
+  async start(): Promise<void> {
+    // this.browser = await puppeteer.launch({
+    //   executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+    // });
+    this.browser = await puppeteer.launch();
+    this.page = await this.browser.newPage();
+    const [name, other] = this.cookie.split('=');
+    const [value] = other.split(';');
+    await this.page.setCookie({
+      name,
+      value,
+      url: this.__getServerUrl()
+    });
+    await this.page.setViewport({
+      width: 1280,
+      height: 960
+    });
+    await this.page.goto(this.loginUrl);
+  }
 
-    private __getServerUrl() {
-        return `https://s${this.account.server.number}-${this.account.server.language}.ogame.gameforge.com`;
-    }
+  private __getServerUrl() {
+    return `https://s${this.account.server.number}-${this.account.server.language}.ogame.gameforge.com`;
+  }
 
-    /**
-     * Stop the game api. You should called this before exiting your program.
-     */
-    async stop(): Promise<void> {
-        await this.browser.close();
-    }
+  /**
+   * Stop the game api. You should called this before exiting your program.
+   */
+  async stop(): Promise<void> {
+    await this.browser.close();
+  }
 
-    /**
-     * List your ressources
-     */
-    async resourcesList(): Promise<ResourceList> {
-        await this.navigation.goToHomePage(this.page);
-        return loadResources(this.page);
-    }
+  /**
+   * List your ressources
+   */
+  async resourcesList(): Promise<ResourceList> {
+    await this.navigation.goToHomePage(this.page);
+    return loadResources(this.page);
+  }
 
-    /**
-     * List your mines and storage
-     */
-    async resourceFactoryList(): Promise<ResourceFactoryList> {
-        await this.navigation.goToResourcePage(this.page);
-        const res = await loadMinesAndStorage(this.page);
-        return res;
-    }
+  /**
+   * List your mines and storage
+   */
+  async resourceFactoryList(): Promise<ResourceFactoryList> {
+    await this.navigation.goToResourcePage(this.page);
+    const res = await loadMinesAndStorage(this.page);
+    return res;
+  }
 
-    /**
-     * List your facilities
-     */
-    async facilitiesList() : Promise<FacilitiesList> {
-        await this.navigation.goToFacilitiesPage(this.page);
-        return loadFacilities(this.page);
-    }
+  /**
+   * List your facilities
+   */
+  async facilitiesList(): Promise<FacilitiesList> {
+    await this.navigation.goToFacilitiesPage(this.page);
+    return loadFacilities(this.page);
+  }
 
-    /**
-     * List you research
-     */
-    async researchList(): Promise<ResearchList> {
-        await this.navigation.goToResearchPage(this.page);
-        return loadResearch(this.page);
-    }
+  /**
+   * List you research
+   */
+  async researchList(): Promise<ResearchList> {
+    await this.navigation.goToResearchPage(this.page);
+    return loadResearch(this.page);
+  }
 
-    /**
-     * List your ships
-     */
-    async shipList(): Promise<ShipList> {
-        await this.navigation.goToShipPage(this.page);
-        return loadShips(this.page);
-    }
+  /**
+   * List your ships
+   */
+  async shipList(): Promise<ShipList> {
+    await this.navigation.goToShipPage(this.page);
+    return loadShips(this.page);
+  }
 
-    /**
-     * List your defenses
-     */
-    async defenseList(): Promise<DefenseList> {
-        await this.navigation.goToDefensePage(this.page);
-        return loadDefenses(this.page);
-    }
+  /**
+   * List your defenses
+   */
+  async defenseList(): Promise<DefenseList> {
+    await this.navigation.goToDefensePage(this.page);
+    return loadDefenses(this.page);
+  }
 
-    /**
-     * Upgrade or create a building. Don't use it for ships/defenses
-     * @param building The building to upgrade
-     */
-    async makeUpgrade(building: BuildingLight): Promise<void> {
-        const resources = await this.resourcesList();
-        if (!this.canUpgrade(building, resources)) {
-            throw new Error(`Can't upgrade`);
-        }
-        await this.page.goto(building.upgrade.url);
-    }
+  /**
+   * List fleet movements
+   */
+  async fleetMovementsList(): Promise<FleetMovement[]> {
+    await this.navigation.goToFleetMovementsPage(this.page);
+    return loadFleetMovements(this.page);
+  }
 
-    private haveEnoughResource(upgrade: Upgrade, resources: ResourceList, count: number = 1): boolean {
-        return !Object.keys(upgrade.costs).some((resource: ResourceType) => {
-            if (resource === 'energy') return false;
-            if (resources[resource] < upgrade.costs[resource] * count) {
-                return true;
-            } else {
-                return false;
-            }
-        });
-    }
+  /**
+   * List your planets
+   */
+  async planetsList(): Promise<Planet[]> {
+    await this.navigation.goToOverviewPage(this.page);
+    return loadPlanets(this.page);
+  }
 
-    /**
-     * Check if you can upgrade a building
-     * @param building the building to upgrade
-     * @param resources Optional parameter, if provided it will speed up the fonction
-     */
-    async canUpgrade(building: BuildingLight, resources?: ResourceList): Promise<boolean> {
-        if (!resources) resources = await this.resourcesList();
-        const upgrade = building.upgrade;
-        return upgrade.url && this.haveEnoughResource(upgrade, resources);
-    }
+  /**
+   * Select on of your planets
+   */
+  async selectPlanet(planetId: string): Promise<void> {
+    await this.navigation.goToPlanetOverviewPage(this.page, planetId);
+  }
 
-    /**
-     * Check if you can create a certain amount of ship/defense
-     * @param item Ship or Defense
-     * @param count The number of items you wants to create
-     * @param resources Optional parameter, if provided it will speed up the fonction
-     */
-    async canCreate(item: Ship | Defense, count: number = 1, resources?: ResourceList): Promise<boolean> {
-        if (!resources) resources = await this.resourcesList();
-        return this.haveEnoughResource(item.upgrade, resources, count) && (item.status === 'on' || item.status === 'active');
+  /**
+   * Upgrade or create a building. Don't use it for ships/defenses
+   * @param building The building to upgrade
+   */
+  async makeUpgrade(building: BuildingLight): Promise<void> {
+    const resources = await this.resourcesList();
+    if (!this.canUpgrade(building, resources)) {
+      throw new Error(`Can't upgrade`);
     }
+    await this.page.goto(building.upgrade.url);
+  }
 
-    /**
-     * Create a ship
-     * @param ship ship to create
-     * @param count number of ship to create
-     */
-    async createShip(ship: Ship, count: number = 1) {
-        if (!await this.canCreate(ship, count)) {
-            throw new Error(`Not enough resources`);
-        }
-        await this.navigation.goToShipPage(this.page);
-        await createShipFromPannel(this.page, ship, count);
-    }
+  private haveEnoughResource(upgrade: Upgrade, resources: ResourceList, count: number = 1): boolean {
+    return !Object.keys(upgrade.costs).some((resource: ResourceType) => {
+      if (resource === 'energy') return false;
+      if (resources[resource] < upgrade.costs[resource] * count) {
+        return true;
+      } else {
+        return false;
+      }
+    });
+  }
 
-    /**
-     * Create a defense
-     * @param defense defense to create
-     * @param count number of defense to create
-     */
-    async createDefense(defense: Defense, count: number = 1) {
-        if (!await this.canCreate(defense, count)) {
-            throw new Error(`Not enough resources`);
-        }
-        await this.navigation.goToDefensePage(this.page);
-        await createDefenseFromPannel(this.page, defense, count);
+  /**
+   * Check if you can upgrade a building
+   * @param building the building to upgrade
+   * @param resources Optional parameter, if provided it will speed up the fonction
+   */
+  async canUpgrade(building: BuildingLight, resources?: ResourceList): Promise<boolean> {
+    if (!resources) resources = await this.resourcesList();
+    const upgrade = building.upgrade;
+    return upgrade.url && this.haveEnoughResource(upgrade, resources);
+  }
+
+  /**
+   * Check if you can create a certain amount of ship/defense
+   * @param item Ship or Defense
+   * @param count The number of items you wants to create
+   * @param resources Optional parameter, if provided it will speed up the fonction
+   */
+  async canCreate(item: Ship | Defense, count: number = 1, resources?: ResourceList): Promise<boolean> {
+    if (!resources) resources = await this.resourcesList();
+    return (
+      this.haveEnoughResource(item.upgrade, resources, count) && (item.status === 'on' || item.status === 'active')
+    );
+  }
+
+  /**
+   * Create a ship
+   * @param ship ship to create
+   * @param count number of ship to create
+   */
+  async createShip(ship: Ship, count: number = 1) {
+    if (!(await this.canCreate(ship, count))) {
+      throw new Error(`Not enough resources`);
     }
+    await this.navigation.goToShipPage(this.page);
+    await createShipFromPannel(this.page, ship, count);
+  }
+
+  /**
+   * Create a defense
+   * @param defense defense to create
+   * @param count number of defense to create
+   */
+  async createDefense(defense: Defense, count: number = 1) {
+    if (!(await this.canCreate(defense, count))) {
+      throw new Error(`Not enough resources`);
+    }
+    await this.navigation.goToDefensePage(this.page);
+    await createDefenseFromPannel(this.page, defense, count);
+  }
 }

--- a/src/Api/game/navigation.ts
+++ b/src/Api/game/navigation.ts
@@ -1,32 +1,44 @@
-import { Page } from "puppeteer";
+import { Page } from 'puppeteer';
 
 export class Navigation {
-    serverUrl: string;
-    constructor(serverUrl: string) {
-        this.serverUrl = serverUrl;
-    }
+  serverUrl: string;
+  constructor(serverUrl: string) {
+    this.serverUrl = serverUrl;
+  }
 
-    async goToHomePage(page: Page) {
-        await page.goto(`${this.serverUrl}/game`);
-    }
+  async goToHomePage(page: Page) {
+    await page.goto(`${this.serverUrl}/game`);
+  }
 
-    async goToResourcePage(page: Page) {
-        await page.goto(`${this.serverUrl}/game/index.php?page=ingame&component=supplies`);
-    }
+  async goToResourcePage(page: Page) {
+    await page.goto(`${this.serverUrl}/game/index.php?page=ingame&component=supplies`);
+  }
 
-    async goToFacilitiesPage(page: Page) {
-        await page.goto(`${this.serverUrl}/game/index.php?page=ingame&component=facilities`);
-    }
+  async goToFacilitiesPage(page: Page) {
+    await page.goto(`${this.serverUrl}/game/index.php?page=ingame&component=facilities`);
+  }
 
-    async goToResearchPage(page: Page) {
-        await page.goto(`${this.serverUrl}/game/index.php?page=ingame&component=research`);
-    }
+  async goToResearchPage(page: Page) {
+    await page.goto(`${this.serverUrl}/game/index.php?page=ingame&component=research`);
+  }
 
-    async goToShipPage(page: Page) {
-        await page.goto(`${this.serverUrl}/game/index.php?page=ingame&component=shipyard`);
-    }
+  async goToShipPage(page: Page) {
+    await page.goto(`${this.serverUrl}/game/index.php?page=ingame&component=shipyard`);
+  }
 
-    async goToDefensePage(page: Page) {
-        await page.goto(`${this.serverUrl}/game/index.php?page=ingame&component=defenses`);
-    }
+  async goToDefensePage(page: Page) {
+    await page.goto(`${this.serverUrl}/game/index.php?page=ingame&component=defenses`);
+  }
+
+  async goToFleetMovementsPage(page: Page) {
+    await page.goto(`${this.serverUrl}/game/index.php?page=ingame&component=movement`);
+  }
+
+  async goToOverviewPage(page: Page) {
+    await page.goto(`${this.serverUrl}/game/index.php?page=ingame&component=overview`);
+  }
+
+  async goToPlanetOverviewPage(page: Page, planetId: string) {
+    await page.goto(`${this.serverUrl}/game/index.php?page=ingame&component=overview&cp=${planetId}`);
+  }
 }

--- a/src/Api/game/parsing/fleetMovements.ts
+++ b/src/Api/game/parsing/fleetMovements.ts
@@ -1,0 +1,44 @@
+import { ElementHandle, Page } from 'puppeteer';
+import { FleetMovement, FleetMovementType, FleetReturnFlightType } from '../types';
+
+export async function loadFleetMovements(page: Page): Promise<FleetMovement[]> {
+  const elems = await page.$$('[class*="fleetDetails"]');
+  const fleetMovementsList: FleetMovement[] = [];
+  for (const elem of elems) {
+    // console.log('elem : ', elem);
+    fleetMovementsList.push(await loadFleetMovementLight(elem, page));
+  }
+  return fleetMovementsList;
+}
+
+export async function loadFleetMovementLight(elem: ElementHandle<Element>, page: Page): Promise<FleetMovement> {
+  const id = (await elem.evaluate(e => e.getAttribute('id'))).replace('fleet', '');
+  const elemType = await elem.evaluate(e => e.getAttribute('data-mission-type'));
+  let type = FleetMovementType.unknown;
+  if (elemType === FleetMovementType.attack) {
+    type = FleetMovementType.attack;
+  } else if (elemType === FleetMovementType.exploit) {
+    type = FleetMovementType.exploit;
+  } else if (elemType === FleetMovementType.spy) {
+    type = FleetMovementType.spy;
+  } else if (elemType === FleetMovementType.transport) {
+    type = FleetMovementType.transport;
+  }
+  const elemReturnFLight = await await elem.evaluate(e => e.getAttribute('data-return-flight'));
+  let returnFLight = FleetReturnFlightType.unknown;
+  if (elemReturnFLight === FleetReturnFlightType.go) {
+    returnFLight = FleetReturnFlightType.go;
+  } else if (elemReturnFLight === FleetReturnFlightType.return) {
+    returnFLight = FleetReturnFlightType.return;
+  } else if (elemReturnFLight === FleetReturnFlightType.otherPLayer) {
+    returnFLight = FleetReturnFlightType.otherPLayer;
+  }
+  const arrivalTime = Number(await elem.evaluate(e => e.getAttribute('data-arrival-time')));
+  return {
+    id,
+    __elem: elem,
+    type,
+    returnFLight,
+    arrivalTime
+  };
+}

--- a/src/Api/game/parsing/planets.ts
+++ b/src/Api/game/parsing/planets.ts
@@ -1,0 +1,23 @@
+import { ElementHandle, Page } from 'puppeteer';
+import { Planet } from '../types';
+
+export async function loadPlanets(page: Page): Promise<Planet[]> {
+  const elems = await page.$$('#planetList div');
+  const planetsList: Planet[] = [];
+  for (const elem of elems) {
+    planetsList.push(await loadPlanetLight(elem, page));
+  }
+  return planetsList;
+}
+
+export async function loadPlanetLight(elem: ElementHandle<Element>, page: Page): Promise<Planet> {
+  const id = (await elem.evaluate(e => e.getAttribute('id'))).replace('planet-', '');
+  const type = (await elem.evaluate(e => e.getAttribute('class'))).split(' ')[0];
+  const name = await (await elem.$('.planet-name')).evaluate(e => e.textContent);
+  return {
+    id,
+    __elem: elem,
+    type,
+    name
+  };
+}

--- a/src/Api/game/types.ts
+++ b/src/Api/game/types.ts
@@ -1,7 +1,7 @@
-import { ElementHandle } from "puppeteer";
+import { ElementHandle } from 'puppeteer';
 
 export type RecordConditional<K extends keyof any, T> = {
-    [P in K]?: T;
+  [P in K]?: T;
 };
 
 export type ResourceType = 'metal' | 'crystal' | 'deuterium' | 'energy' | 'darkmatter';
@@ -9,80 +9,208 @@ export const ALL_RESOURCES: ResourceType[] = ['metal', 'crystal', 'deuterium', '
 export type ResourceList = Record<ResourceType, number>;
 
 export interface Upgrade {
-    url?: string;
-    costs: ResourceList;
-    time: number;
+  url?: string;
+  costs: ResourceList;
+  time: number;
 }
 
 export type Status = 'disabled' | 'on' | 'off' | 'active';
 export const ALL_STATUS: Status[] = ['disabled', 'on', 'off', 'active'];
 
+export enum FleetMovementType {
+  unknown = 'unknown',
+  transport = '3',
+  attack = '4',
+  spy = '6',
+  exploit = '8'
+}
+
+export enum FleetReturnFlightType {
+  unknown = 'unknown',
+  go = '',
+  return = '1',
+  otherPLayer = 'false'
+}
+
+export interface FleetMovement {
+  id: string;
+  __elem?: ElementHandle<Element>;
+  type: FleetMovementType;
+  returnFLight: FleetReturnFlightType;
+  arrivalTime: number;
+}
+
+export interface Planet {
+  id: string;
+  __elem?: ElementHandle<Element>;
+  type: string;
+  name: string;
+}
+
 export interface BuildingLight {
-    id: number;
-    status: Status;
-    level: number;
-    upgrade: Upgrade;
+  id: number;
+  status: Status;
+  level: number;
+  upgrade: Upgrade;
 }
 
 export type BuildingType = string;
 export interface Building<T extends BuildingType> extends BuildingLight {
-    type: T;
-    __elem?: ElementHandle<Element>;
+  type: T;
+  __elem?: ElementHandle<Element>;
 }
 export type BuildingList<T extends BuildingType> = RecordConditional<T, Building<T>>;
 
 export type MineType = 'metalMine' | 'crystalMine' | 'deuteriumSynthesizer' | 'solarPlant' | 'fusionPlant';
 export const ALL_MINES: MineType[] = ['metalMine', 'crystalMine', 'deuteriumSynthesizer', 'solarPlant', 'fusionPlant'];
 export interface Mine extends Building<MineType> {
-    resource: ResourceType;
+  resource: ResourceType;
 }
 export type MineList = RecordConditional<MineType, Mine>;
 
 export type StorageType = 'metalStorage' | 'crystalStorage' | 'deuteriumStorage';
 export const ALL_STORAGES: StorageType[] = ['metalStorage', 'crystalStorage', 'deuteriumStorage'];
 export interface Storage extends Building<StorageType> {
-    capacity: number;
-    resource: ResourceType;
+  capacity: number;
+  resource: ResourceType;
 }
 export type StorageList = RecordConditional<StorageType, Storage>;
 
 export interface ResourceFactoryList {
-    mines: MineList;
-    storages: StorageList;
+  mines: MineList;
+  storages: StorageList;
 }
 
-export type FacilitieType = 'roboticsFactory' | 'shipyard' | 'researchLaboratory' | 'allianceDepot' | 'missileSilo' | 'naniteFactory' | 'terraformer' | 'repairDock';
-export const ALL_FACILITIES: FacilitieType[] = ['roboticsFactory', 'shipyard', 'researchLaboratory', 'allianceDepot', 'missileSilo', 'naniteFactory', 'terraformer', 'repairDock'];
+export type FacilitieType =
+  | 'roboticsFactory'
+  | 'shipyard'
+  | 'researchLaboratory'
+  | 'allianceDepot'
+  | 'missileSilo'
+  | 'naniteFactory'
+  | 'terraformer'
+  | 'repairDock';
+export const ALL_FACILITIES: FacilitieType[] = [
+  'roboticsFactory',
+  'shipyard',
+  'researchLaboratory',
+  'allianceDepot',
+  'missileSilo',
+  'naniteFactory',
+  'terraformer',
+  'repairDock'
+];
 export interface Facilities extends Building<FacilitieType> {
-    capacity?: number;
+  capacity?: number;
 }
 export type FacilitiesList = RecordConditional<FacilitieType, Facilities>;
 
-export type ResearchType = 'energyTechnology' | 'laserTechnology' | 'ionTechnology' | 'hyperspaceTechnology' |
-    'plasmaTechnology' | 'combustionDriveTechnology' | 'impulseDriveTechnology' | 'hyperspaceDriveTechnology' |
-    'espionageTechnology' | 'computerTechnology' | 'astrophysicsTechnology' | 'researchNetworkTechnology' |
-    'gravitonTechnology' | 'weaponsTechnology' | 'shieldingTechnology' | 'armorTechnology';
-export const ALL_RESEARCH: ResearchType[] = ['energyTechnology', 'laserTechnology', 'ionTechnology', 'hyperspaceTechnology',
-    'plasmaTechnology', 'combustionDriveTechnology', 'impulseDriveTechnology', 'hyperspaceDriveTechnology',
-    'espionageTechnology', 'computerTechnology', 'astrophysicsTechnology', 'researchNetworkTechnology',
-    'gravitonTechnology', 'weaponsTechnology', 'shieldingTechnology', 'armorTechnology'];
+export type ResearchType =
+  | 'energyTechnology'
+  | 'laserTechnology'
+  | 'ionTechnology'
+  | 'hyperspaceTechnology'
+  | 'plasmaTechnology'
+  | 'combustionDriveTechnology'
+  | 'impulseDriveTechnology'
+  | 'hyperspaceDriveTechnology'
+  | 'espionageTechnology'
+  | 'computerTechnology'
+  | 'astrophysicsTechnology'
+  | 'researchNetworkTechnology'
+  | 'gravitonTechnology'
+  | 'weaponsTechnology'
+  | 'shieldingTechnology'
+  | 'armorTechnology';
+export const ALL_RESEARCH: ResearchType[] = [
+  'energyTechnology',
+  'laserTechnology',
+  'ionTechnology',
+  'hyperspaceTechnology',
+  'plasmaTechnology',
+  'combustionDriveTechnology',
+  'impulseDriveTechnology',
+  'hyperspaceDriveTechnology',
+  'espionageTechnology',
+  'computerTechnology',
+  'astrophysicsTechnology',
+  'researchNetworkTechnology',
+  'gravitonTechnology',
+  'weaponsTechnology',
+  'shieldingTechnology',
+  'armorTechnology'
+];
 export interface Research extends Building<ResearchType> {}
 export type ResearchList = RecordConditional<ResearchType, Research>;
 
-export type ShipType = 'fighterLight' | 'fighterHeavy' | 'cruiser' | 'battleship' | 'interceptor' | 'bomber' | 'destroyer' | 'deathstar' |
-    'reaper' | 'explorer' | 'transporterSmall' | 'transporterLarge' | 'colonyShip' | 'recycler' | 'espionageProbe' | 'solarSatellite' | 'resbuggy';
-export const ALL_BATTLE_SHIP: ShipType[] = ['fighterLight', 'fighterHeavy', 'cruiser', 'battleship', 'interceptor', 'bomber', 'destroyer', 'deathstar', 'reaper', 'explorer'];
-export const ALL_CIVIL_SHIP: ShipType[] = ['transporterSmall', 'transporterLarge', 'colonyShip', 'recycler', 'espionageProbe', 'solarSatellite', 'resbuggy'];
+export type ShipType =
+  | 'fighterLight'
+  | 'fighterHeavy'
+  | 'cruiser'
+  | 'battleship'
+  | 'interceptor'
+  | 'bomber'
+  | 'destroyer'
+  | 'deathstar'
+  | 'reaper'
+  | 'explorer'
+  | 'transporterSmall'
+  | 'transporterLarge'
+  | 'colonyShip'
+  | 'recycler'
+  | 'espionageProbe'
+  | 'solarSatellite'
+  | 'resbuggy';
+export const ALL_BATTLE_SHIP: ShipType[] = [
+  'fighterLight',
+  'fighterHeavy',
+  'cruiser',
+  'battleship',
+  'interceptor',
+  'bomber',
+  'destroyer',
+  'deathstar',
+  'reaper',
+  'explorer'
+];
+export const ALL_CIVIL_SHIP: ShipType[] = [
+  'transporterSmall',
+  'transporterLarge',
+  'colonyShip',
+  'recycler',
+  'espionageProbe',
+  'solarSatellite',
+  'resbuggy'
+];
 export const ALL_SHIP: ShipType[] = [...ALL_BATTLE_SHIP, ...ALL_CIVIL_SHIP];
 export type ShipCategory = 'battle' | 'civil';
 export interface Ship extends Building<ShipType> {
-    category: ShipCategory;
+  category: ShipCategory;
 }
 export type ShipList = RecordConditional<ShipType, Ship>;
 
-export type DefenseType = 'rocketLauncher' | 'laserCannonLight' | 'laserCannonHeavy' | 'gaussCannon' | 'ionCannon' | 'plasmaCannon' |
-    'shieldDomeSmall' | 'shieldDomeLarge' | 'missileInterceptor' | 'missileInterplanetary';
-export const ALL_DEFENSES: DefenseType[] = ['rocketLauncher', 'laserCannonLight', 'laserCannonHeavy', 'gaussCannon', 'ionCannon', 'plasmaCannon',
-    'shieldDomeSmall', 'shieldDomeLarge', 'missileInterceptor', 'missileInterplanetary'];
+export type DefenseType =
+  | 'rocketLauncher'
+  | 'laserCannonLight'
+  | 'laserCannonHeavy'
+  | 'gaussCannon'
+  | 'ionCannon'
+  | 'plasmaCannon'
+  | 'shieldDomeSmall'
+  | 'shieldDomeLarge'
+  | 'missileInterceptor'
+  | 'missileInterplanetary';
+export const ALL_DEFENSES: DefenseType[] = [
+  'rocketLauncher',
+  'laserCannonLight',
+  'laserCannonHeavy',
+  'gaussCannon',
+  'ionCannon',
+  'plasmaCannon',
+  'shieldDomeSmall',
+  'shieldDomeLarge',
+  'missileInterceptor',
+  'missileInterplanetary'
+];
 export interface Defense extends Building<DefenseType> {}
 export type DefenseList = RecordConditional<DefenseType, Defense>;


### PR DESCRIPTION
Here is a little upgrade of the game API for listing planets and fleet movements.
There is, also, the option to select a planet.

The goal, in the next days is to be able, in the bot for example, to auto save ressources when it detects an incoming attack.

The planet selection is usefull to manage more than one planet. Currently the bot can only manage the main world

NB : Many changes comes from my workplace code formater wich makes lines return when they are too long and replace " by ' when possible.
Sorry for that.